### PR TITLE
Fix org template nested expansion

### DIFF
--- a/capture-org-template.el
+++ b/capture-org-template.el
@@ -48,17 +48,19 @@
     (org-map-entries
      (lambda ()
        (let ((heading (substring-no-properties (org-get-heading)))
-             (type (or (org-entry-get nil "TYPE") "entry"))
+             (type (org-entry-get nil "TYPE"))
              (key (org-entry-get nil "KEY"))
              (target (org-entry-get nil "TARGET"))
              (options (or (org-entry-get nil "OPTIONS") "")))
          (unless key (error "All root level headlines must have :KEY: property. '%s' did not" heading))
          (unless target (error "All root level headlines must have :TARGET: property. '%s' did not" heading))
          (outline-next-heading)
+         (if (> (org-outline-level) 1)
          (org-copy-subtree 1)
+         (kill-new ""))
          (append (list key
                        heading
-                       (intern type)
+                       (if type (intern type))
                        (capture-org-template--read-expression target)
                        (capture-org-template--drop-one-level (substring-no-properties (car kill-ring))))
                  (capture-org-template--read-expression options)))

--- a/capture-org-template.el
+++ b/capture-org-template.el
@@ -48,7 +48,7 @@
     (org-map-entries
      (lambda ()
        (let ((heading (substring-no-properties (org-get-heading)))
-             (type (org-entry-get nil "TYPE"))
+             (type (or (org-entry-get nil "TYPE") "entry"))
              (key (org-entry-get nil "KEY"))
              (target (org-entry-get nil "TARGET"))
              (options (or (org-entry-get nil "OPTIONS") "")))
@@ -59,10 +59,12 @@
          (org-copy-subtree 1)
          (kill-new ""))
          (append (list key
-                       heading
-                       (if type (intern type))
-                       (capture-org-template--read-expression target)
-                       (capture-org-template--drop-one-level (substring-no-properties (car kill-ring))))
+                       heading)
+                 (when (not (string= type "prefix"))
+                   (list
+                    (intern type)
+                    (capture-org-template--read-expression target)
+                    (capture-org-template--drop-one-level (substring-no-properties (car kill-ring)))))
                  (capture-org-template--read-expression options)))
        ) "LEVEL=1" 'nil)))
 
@@ -82,7 +84,7 @@
 %s\n"
               (nth 1 template)
               (nth 1 template)
-              (nth 2 template)
+              (or (nth 2 template) "prefix")
               (nth 0 template)
               (mapconcat (lambda (x) (format "%S" x)) (nth 3 template) " ")
               (if (nth 5 template)

--- a/capture-org-template.el
+++ b/capture-org-template.el
@@ -83,11 +83,17 @@
               (nth 2 template)
               (nth 0 template)
               (mapconcat (lambda (x) (format "%S" x)) (nth 3 template) " ")
-              (if (subseq template 5)
-                  (format " :OPTIONS: %s\n" (mapconcat (lambda (x) (format "%s" x)) (subseq template 5) " "))
+              (if (nth 5 template)
+                  (format " :OPTIONS: %s\n"
+                          (mapconcat
+                           (lambda (x)
+                             (format "%s" x))
+                           (subseq template 5) " "))
                 "")
+              (if (nth 4 template)
               (mapconcat 'capture-org-template--up-one-level
-                         (split-string (nth 4 template) "\n") "\n")))
+                         (split-string (nth 4 template) "\n") "\n")
+              "")))
            org-capture-templates) ""))
 
 (defun capture-org-export-templates-to-org (file)

--- a/example.org
+++ b/example.org
@@ -50,6 +50,24 @@
   :END:
 ** TODO %:fromname: %a %?
    DEADLINE: %(org-insert-time-stamp (org-read-date nil t "+2d"))
+* Templates under prefix 'p'
+ :PROPERTIES:
+ :DESCRIPTION: Templates under prefix 'p'
+ :TYPE: prefix
+ :KEY:      p
+ :TARGET:
+ :END:
+* Sub-template under prefix 'p' todo
+ :PROPERTIES:
+ :DESCRIPTION: p-local todo
+ :TYPE: entry
+ :KEY:      pt
+ :TARGET:   file+headline +org-capture-project-todo-file "Inbox"
+ :OPTIONS: :prepend t
+ :END:
+** TODO %?
+%i
+%a
 * Add new capture template
   :PROPERTIES:
   :KEY:      M
@@ -59,8 +77,3 @@
 ** %^{Capture name}
   %^{KEY}p%^{TARGET|file "~/Org/todo.org"}p%^{DESCRIPTION}p
 *** %?
-     
-
-
-
-


### PR DESCRIPTION
Modified export--string and capture-org-template to handle prefix groups for capturing templates. 

For example, 
'(("p" "Templates for projects") ("pt" "Project-local todo" entry ...))

See example.org for added examples. 