### PR TITLE
Add plaintext item handling

### DIFF
--- a/capture-org-template.el
+++ b/capture-org-template.el
@@ -40,13 +40,15 @@
   "Convert string in STRING to elisp"
   (car (read-from-string (format "(%s)" string))))
 
-(defun capture-org-template--copy-paragraph-next-headline (N)
-  "Reads the plain text paragraph of the current headline text only.
-   For plaintext templates, items, checkitems, etc"
-  (let*
-      ((beg (progn (org-forward-paragraph (or N 2)) (point))) ;; forward 2 skips PROP drawer
-       (end (progn (or (outline-next-heading) (end-of-buffer)) (point))))
-    (kill-ring-save beg end)))
+(defun capture-org-template--read-body ()
+  "Return body text of current headline (after metadata) up to next headline."
+  (save-excursion
+    (org-back-to-heading t)
+    (org-end-of-meta-data t)                  ;; after drawers/planning/blank lines
+    (let* ((beg (point))
+           (end (save-excursion
+                  (or (outline-next-heading) (point-max)))))
+      (buffer-substring-no-properties beg end))))
 
 (defun capture-org-template (file)
   "Read capture org-capture-templates from FILE"
@@ -62,38 +64,34 @@
              (options (or (org-entry-get nil "OPTIONS") "")))
          (unless key (error "All root level headlines must have :KEY: property. '%s' did not" heading))
          (unless target (error "All root level headlines must have :TARGET: property. '%s' did not" heading))
-         ;; Interpret capture types separately
          (cond
-          ;; Prefix requires key, heading only
+          ;; prefix
           ((string= type "prefix")
            (append (list key heading)
                    (capture-org-template--read-expression options)))
-          ((or
-            (string= type "item")
-            (string= type "checkitem")
-            (string= type "table-line")
-            (string= type "plain"))
-           (progn
-             (capture-org-template--copy-paragraph-next-headline 2) ;; forward 2 paragraphs skips PROP drawer
-             (when (> (org-outline-level) 1) (org-copy-subtree 1)
-               (error "Headline in %s entry!" type)) ;; signal error when entry contains headline
-           (append (list key heading (intern type)
-                   (capture-org-template--read-expression target)
-                   ;; TODO interpret plain text,  extract content
-                   (substring-no-properties (car kill-ring)))
-                   (capture-org-template--read-expression options))))
-          (t
-           (progn ;; Default type=entry or nil, interpret as headline
-               (outline-next-heading)
-               (if (> (org-outline-level) 1)
-                   (org-copy-subtree 1)
-                 (kill-new ""))
-               (append (list key heading (intern type)
-                       (capture-org-template--read-expression target)
-                       (capture-org-template--drop-one-level (substring-no-properties (car kill-ring))))
-                       (capture-org-template--read-expression options)))))))
-     "LEVEL=1" 'nil)))
 
+          ;; plain text-y types: item/checkitem/table-line/plain
+          ((member type '("item" "checkitem" "table-line" "plain"))
+           (when (> (org-outline-level) 1)
+             (error "Headline in %s entry!" type))
+           (let ((tpl (capture-org-template--read-body)))   ;; ← USE the returned string
+             (append (list key heading (intern type)
+                           (capture-org-template--read-expression target)
+                           tpl)
+                     (capture-org-template--read-expression options))))
+
+          ;; default: entry (headline content)
+          (t
+           (outline-next-heading)
+           (if (> (org-outline-level) 1)
+               (org-copy-subtree 1)
+             (kill-new ""))
+           (append (list key heading (intern type)
+                         (capture-org-template--read-expression target)
+                         (capture-org-template--drop-one-level
+                          (substring-no-properties (car kill-ring))))
+                   (capture-org-template--read-expression options))))))
+     "LEVEL=1" 'nil)))
 
 (defun capture-org-export--string ()
   "Export current org-capture-templates as org string"

--- a/example.org
+++ b/example.org
@@ -50,6 +50,16 @@
   :END:
 ** TODO %:fromname: %a %?
    DEADLINE: %(org-insert-time-stamp (org-read-date nil t "+2d"))
+* Groceries plain list item
+:PROPERTIES:
+:KEY:      s
+:TARGET:   file+olp "~/Org/todo.org" "Groceries"
+:TYPE: checkitem
+:DESCRIPTION: Add grocery item to list
+:OPTIONS: :immediate-finish t
+:END:
+[ ] %^{ITEM}, $%^{COST}
+
 * Templates under prefix 'p'
  :PROPERTIES:
  :DESCRIPTION: Templates under prefix 'p'


### PR DESCRIPTION
Added example using checklists.
Added capture-org-template--copy-paragraph-next-headline()

Created a helper function to kill text between capture headline paragraph text and next headline for plaintext. 
An error is raised if any plaintext headline contains headlines @ level=2 or greater.

Tidied up function to make it explicit using cond statements.